### PR TITLE
Provide the possible enviroment variable options base on the provider…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ Supports modern email providers
 Installation
 You can install the package using your preferred package manager:
 
+## Before calling any provider
+
+Update the .env file with the provider that you wil support:
+
+```env
+# Mailgun
+MAILGUN_API_KEY=<TOKEN>
+MAILGUN_DOMAIN=<DOMAIN>
+
+#Plunk
+PLUNK_API_TOKEN=<TOKEN>
+
+#Postmark
+POSTMARK_SERVER_TOKEN=<token>
+
+#Resend
+RESEND_API_TOKEN=<TOKEN>
+
+#Sendgrid
+SENDGRID_API_KEY=<TOKEN>
+```
+
+
+## Usage
+
 ```ts
 import { useEmail } from "use-email";
 

--- a/src/services/mailgun.ts
+++ b/src/services/mailgun.ts
@@ -28,10 +28,13 @@ export const MailgunService = (): EmailService => {
     if (html) formData.append("html", html);
 
     try {
+      
+      const encodedCredentials = Buffer.from(`api:${MAILGUN_API_KEY}`).toString("base64");
+
       await $fetch(MAILGUN_API_URL, {
         method: "POST",
         headers: {
-          Authorization: `api:${MAILGUN_API_KEY}`,
+          Authorization: `Basic ${encodedCredentials}`,
         },
         body: formData,
       });

--- a/src/services/mailgun.ts
+++ b/src/services/mailgun.ts
@@ -29,7 +29,13 @@ export const MailgunService = (): EmailService => {
 
     try {
       
-      const encodedCredentials = Buffer.from(`api:${MAILGUN_API_KEY}`).toString("base64");
+      const mailgunBasicAuthUsernameAndKey = `api:${MAILGUN_API_KEY}`;
+      const encodedCredentials = typeof Buffer !== "undefined"
+          ? Buffer.from(mailgunBasicAuthUsernameAndKey).toString("base64")
+          // `btoa` in non-Node environments
+          //The merits of using btoa are mixed. 
+          //It’s not actually a deprecated API; it’s merely marked as legacy
+          : btoa(mailgunBasicAuthUsernameAndKey)
 
       await $fetch(MAILGUN_API_URL, {
         method: "POST",


### PR DESCRIPTION
Provide the possible environment variables in the README.


Bug fix:

Problem:

- When an email send is trigger while using the Mailgun provider, the request always fail and return 401 not authorize.

Solution:

Base on the documentation of Mailgun:
> Authentication to the Mailgun API is done by providing an Authorization header using HTTP Basic Auth
- Update the header for the request to use Basic auth with the username and API_KEY in base64

