### PR TITLE
feat: make it able to set api url for EU users

### DIFF
--- a/src/services/mailgun.ts
+++ b/src/services/mailgun.ts
@@ -8,7 +8,7 @@ import type { EmailService } from "../types/email-service";
 export const MailgunService = (): EmailService => {
   const MAILGUN_API_KEY = process.env.MAILGUN_API_KEY;
   const MAILGUN_DOMAIN = process.env.MAILGUN_DOMAIN;
-  const MAILGUN_API_URL = `https://api.mailgun.net/v3/${MAILGUN_DOMAIN}/messages`;
+  const MAILGUN_API_URL = process.env.MAILGUN_API_URL || `https://api.mailgun.net/v3/${MAILGUN_DOMAIN}/messages`;
 
   const send = async (emailOptions: EmailOptions): Promise<void> => {
     if (!MAILGUN_API_KEY || !MAILGUN_DOMAIN) {


### PR DESCRIPTION
EU users need to use another API url: `https://api.eu.mailgun.net/v3/`.
Make it able to set this via env variable and fallback to default one when not set.