### PR TITLE
Add Brevo (sendinblue) as an email service.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { ResendService } from "./services/resend";
 import { SendGridService } from "./services/sendgrid";
 import { MailgunService } from "./services/mailgun";
 import { ZeptoMailService } from "./services/zeptomail";
+import { BrevoService } from "./services/brevo";
 import type { EmailProvider } from "./types/email-options";
 import type { EmailService } from "./types/email-service";
 
@@ -32,6 +33,9 @@ export function useEmail(provider: EmailProvider): EmailService {
     }
     case "zeptomail": {
       return new ZeptoMailService();
+    }
+    case "brevo": {
+      return BrevoService();
     }
     default: {
       throw new Error(`Unsupported email provider: ${provider}`);

--- a/src/services/brevo.ts
+++ b/src/services/brevo.ts
@@ -1,0 +1,49 @@
+import { ofetch as $fetch } from "ofetch";
+import type { EmailOptions } from "../types/email-options";
+import type { EmailService } from "../types/email-service";
+
+/**
+ * Email service implementation for Mailgun
+ */
+export const BrevoService = (): EmailService => {
+  const BREVO_API_KEY = process.env.BREVO_API_KEY;
+  const BREVO_API_URL = "https://api.brevo.com/v3/smtp/email";
+
+  const send = async (emailOptions: EmailOptions): Promise<void> => {
+    if (!BREVO_API_KEY) {
+      throw new Error("Brevo API key is missing");
+    }
+
+    const { to, from, subject, text, html } = emailOptions;
+    if (!to || !from || (!text && !html)) {
+      throw new Error("Required email fields are missing");
+    }
+
+    const payload = {
+      sender: { email: from },
+      to: Array.isArray(to)
+        ? to.map((email) => ({ email }))
+        : [{ email: to }],
+      subject: subject,
+      textContent: text,
+      htmlContent: html,
+    };
+
+    try {
+      await $fetch(BREVO_API_URL, {
+        method: "POST",
+        headers: {
+          "api-key": BREVO_API_KEY,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+      console.log("Email sent via Brevo");
+    } catch (error) {
+      console.error("Failed to send email with Brevo:", error);
+      throw new Error("Email sending failed with Brevo");
+    }
+  };
+
+  return { send };
+};

--- a/src/types/email-options.ts
+++ b/src/types/email-options.ts
@@ -18,4 +18,5 @@ export type EmailProvider =
   | "sendgrid"
   | "postmark"
   | "mailgun"
-  | "zeptomail";
+  | "zeptomail"
+  | "brevo";


### PR DESCRIPTION
This pull request adds [Brevo](https://www.brevo.com/), formerly named *sendinblue* as a service for sending transactional emails with `useEmail`.