### PR TITLE
Add mock service for logging sent emails.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "packageManager": "pnpm@10.6.3",
   "dependencies": {
+    "consola": "^3.4.2",
     "ofetch": "^1.4.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { MailgunService } from "./services/mailgun";
 import { ZeptoMailService } from "./services/zeptomail";
 import type { EmailProvider } from "./types/email-options";
 import type { EmailService } from "./types/email-service";
+import { MockService } from "./services/mock";
 
 /**
  * Factory function to get the email service based on the provider
@@ -32,6 +33,9 @@ export function useEmail(provider: EmailProvider): EmailService {
     }
     case "zeptomail": {
       return new ZeptoMailService();
+    }
+    case "mock": {
+      return MockService();
     }
     default: {
       throw new Error(`Unsupported email provider: ${provider}`);

--- a/src/services/brevo.ts
+++ b/src/services/brevo.ts
@@ -1,0 +1,47 @@
+import { ofetch as $fetch } from "ofetch";
+import type { EmailOptions } from "../types/email-options";
+import type { EmailService } from "../types/email-service";
+
+/**
+ * Email service implementation for Mailgun
+ */
+export const BrevoService = (): EmailService => {
+  const BREVO_API_KEY = process.env.BREVO_API_KEY;
+  const BREVO_API_URL = "https://api.brevo.com/v3/smtp/email" as const;
+
+  const send = async (emailOptions: EmailOptions): Promise<void> => {
+    if (!BREVO_API_KEY) {
+      throw new Error("Brevo API key is missing");
+    }
+
+    const { to, from, subject, text, html } = emailOptions;
+    if (!to || !from || (!text && !html)) {
+      throw new Error("Required email fields are missing");
+    }
+
+    const payload = {
+      sender: { email: from },
+      to: Array.isArray(to) ? to.map((email) => ({ email })) : [{ email: to }],
+      subject: subject,
+      textContent: text,
+      htmlContent: html,
+    };
+
+    try {
+      await $fetch(BREVO_API_URL, {
+        method: "POST",
+        headers: {
+          "api-key": BREVO_API_KEY,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+      console.log("Email sent via Brevo");
+    } catch (error) {
+      console.error("Failed to send email with Brevo:", error);
+      throw new Error("Email sending failed with Brevo");
+    }
+  };
+
+  return { send };
+};

--- a/src/services/mock.ts
+++ b/src/services/mock.ts
@@ -1,0 +1,27 @@
+import type { EmailOptions } from "../types/email-options";
+import type { EmailService } from "../types/email-service";
+import { consola } from "consola";
+import { colors } from "consola/utils";
+
+/**
+ * Email service implementation for Mocking
+ */
+export const MockService = (): EmailService => {
+  const send = async (emailOptions: EmailOptions): Promise<void> => {
+    const { to, from, subject, text, html } = emailOptions;
+    if (!to || !from || (!text && !html)) {
+      throw new Error("Required email fields are missing");
+    }
+
+    const redactedHtml = html ? colors.blue("[html]") : colors.red("-");
+
+    const payload: string = `to: ${to}\nfrom: ${from}\nsubject: ${subject}\ntext: ${text}\nhtml: ${redactedHtml}`;
+
+    consola.box({
+      title: "Email sent",
+      message: payload,
+    });
+  };
+
+  return { send };
+};

--- a/src/types/email-options.ts
+++ b/src/types/email-options.ts
@@ -18,4 +18,5 @@ export type EmailProvider =
   | "sendgrid"
   | "postmark"
   | "mailgun"
-  | "zeptomail";
+  | "zeptomail"
+  | "mock";


### PR DESCRIPTION
Add a mock service which logs emails to the console instead of sending them. For development purposes.
Uses consola to format the email:

<img width="587" alt="Screenshot 2025-04-20 at 00 16 16" src="https://github.com/user-attachments/assets/f0b6a764-f143-4897-8640-0244974daf32" />

This can be used in your app as follows:

```ts
const provider = process.env.NODE_ENV === 'development' ? 'mock' : 'mailgun'; // replace mailgun with whatever provider you use
useEmail(provider).send({
    to: "test@test.com",
    from: "test@test.com",
    subject: "Test",
    text: "Test",
});
```